### PR TITLE
accept consul_bootstrap_expect as string from jinja template

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -38,8 +38,7 @@
 - name: test if consul_bootstrap_expect is set correctly
   ansible.builtin.assert:
     that:
-      - consul_bootstrap_expect is number
-      - consul_bootstrap_expect in [ 1, 3, 5 ]
+      - consul_bootstrap_expect | int in [ 1, 3, 5 ]
     quiet: yes
   when:
     - consul_bootstrap_expect is defined


### PR DESCRIPTION
leftover from #1: accept consul_bootstrap_expect as a string for compatibility with when Jinja only returns strings