### PR TITLE
consul_encrypt is base64 encoded

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -54,9 +54,9 @@
   ansible.builtin.assert:
     that:
       - consul_encrypt is string
-      - consul_encrypt | length == 32
+      - consul_encrypt | length == 44
     quiet: yes
-    fail_msg: "consul_encrypt must be 32 characters, it's {{ consul_encrypt | length }}."
+    fail_msg: "consul_encrypt must be a 32-byte key encoded with base64 resulting in 44 characters, but it's {{ consul_encrypt | length }}."
   when:
     - consul_encrypt is defined
 


### PR DESCRIPTION
The assertion needs to take into account that the key generated by `consul keygen` is a 32-byte string encoded with base64 resulting in a string of length 44